### PR TITLE
빠진 cstdint include 추가

### DIFF
--- a/extern/include/dxrt/extern/cxxopts.hpp
+++ b/extern/include/dxrt/extern/cxxopts.hpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #define CXXOPTS_HPP_INCLUDED
 
 #include <cstring>
+#include <cstdint>
 #include <exception>
 #include <limits>
 #include <initializer_list>


### PR DESCRIPTION
GCC 15 환경에서 uint8_t 와 같은 타입을 사용하기 위해 cstdint 인클루드가 필요함이 확인됨. (참고: https://gcc.gnu.org/gcc-15/porting_to.html)

컴파일 오류를 고치기 위해 device_util.h 에 cstdint 인클루드를 추가함.